### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<org.aspectj-version>1.6.11</org.aspectj-version>
 		<org.aspectj-jweaver-version>1.6.12</org.aspectj-jweaver-version>
 				
-		<org.apache.commons-collections>3.2.1</org.apache.commons-collections>
+		<org.apache.commons-collections>3.2.2</org.apache.commons-collections>
 		<org.apache.shiro-version>1.2.2</org.apache.shiro-version>
 		<org.apache.tomcat.dbcp_version>6.0.29</org.apache.tomcat.dbcp_version>
 		


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/